### PR TITLE
Pacote alteracoes bancard moedas e cambios

### DIFF
--- a/app/Http/Controllers/BancardV2Controller.php
+++ b/app/Http/Controllers/BancardV2Controller.php
@@ -69,10 +69,14 @@ class BancardV2Controller extends Controller
                     'process_id' => $data['process_id'],
                 ]);
 
+                $pygSymbol = $this->resolvePygSymbol();
+
                 return view('payment.bancard-v2', [
                     'order' => $order,
                     'processId' => $data['process_id'],
                     'checkoutJsUrl' => $this->bancard->getCheckoutJsUrl(),
+                    'totalInPyg' => $amount,
+                    'pygSymbol' => $pygSymbol,
                 ]);
             }
 
@@ -242,15 +246,16 @@ class BancardV2Controller extends Controller
 
         $order = Order::where('shop_process_id', $shopProcessId)->first();
         $displayPayload = session()->pull('bancard_v2_error_payload');
+        $pygSymbol = $this->resolvePygSymbol();
 
         if (is_array($displayPayload) && (string) data_get($displayPayload, 'shopProcessId') === $shopProcessId) {
-            return view('payment.bancard-v2-error', $displayPayload);
+            return view('payment.bancard-v2-error', $displayPayload + ['pygSymbol' => $pygSymbol]);
         }
 
         $confirmation = $this->bancard->fetchSingleBuyConfirmation($shopProcessId);
         $displayPayload = $this->bancard->buildErrorDisplayPayload($shopProcessId, $confirmation, $order, $status);
 
-        return view('payment.bancard-v2-error', $displayPayload);
+        return view('payment.bancard-v2-error', $displayPayload + ['pygSymbol' => $pygSymbol]);
     }
 
     public function successPage(Request $request): View|RedirectResponse
@@ -263,9 +268,10 @@ class BancardV2Controller extends Controller
 
         $order = Order::where('shop_process_id', $shopProcessId)->first();
         $displayPayload = session()->pull('bancard_v2_success_payload');
+        $pygSymbol = $this->resolvePygSymbol();
 
         if (is_array($displayPayload) && (string) data_get($displayPayload, 'shopProcessId') === $shopProcessId) {
-            return view('payment.bancard-v2-success', $displayPayload);
+            return view('payment.bancard-v2-success', $displayPayload + ['pygSymbol' => $pygSymbol]);
         }
 
         $confirmation = $this->bancard->fetchSingleBuyConfirmation($shopProcessId);
@@ -276,6 +282,7 @@ class BancardV2Controller extends Controller
             'shopProcessId' => $displayPayload['shopProcessId'],
             'amount' => $displayPayload['amount'],
             'responseDescription' => $displayPayload['responseDescription'],
+            'pygSymbol' => $pygSymbol,
         ]);
     }
 
@@ -350,6 +357,13 @@ class BancardV2Controller extends Controller
         }
 
         Cart::where('user_id', $order->user_id)->delete();
+    }
+
+    private function resolvePygSymbol(): string
+    {
+        $pygCurrency = \App\Models\Currency::where('name', 'PYG')->first();
+
+        return $pygCurrency?->sign ?? 'G$';
     }
 
 

--- a/app/Http/Controllers/BancardV2Controller.php
+++ b/app/Http/Controllers/BancardV2Controller.php
@@ -40,7 +40,7 @@ class BancardV2Controller extends Controller
         }
 
         try {
-            $amount = $this->formatAmount($order->total);
+            $amount = $this->convertOrderTotalToPyg($order);
             $currency = self::CURRENCY;
             $shopProcessId = $this->bancard->generateShopProcessId($order);
             $token = $this->bancard->buildSingleBuyToken($shopProcessId, $amount, $currency);
@@ -91,6 +91,24 @@ class BancardV2Controller extends Controller
 
             return redirect()->route('checkout.index')->with('error', 'Erro ao iniciar pagamento Bancard V2.');
         }
+    }
+
+    /**
+     * Converte o valor total do pedido para PYG usando a cotação cadastrada.
+     */
+    private function convertOrderTotalToPyg(Order $order): string
+    {
+        $valorBase = $order->total;
+        $valorMoeda = $order->currency_value ?? 1;
+        $moedaBase = $order->currency_sign ?? 'USD';
+
+        // Buscar taxa do PYG
+        $pyg = \App\Models\Currency::where('sign', 'GS$')->orWhere('name', 'PYG')->first();
+        $taxaPyg = $pyg->value ?? 1;
+
+        // Converter para PYG
+        $valorEmPyg = $valorBase * ($taxaPyg / $valorMoeda);
+        return number_format($valorEmPyg, 2, '.', '');
     }
 
     public function cancelCheckout(Order $order): RedirectResponse

--- a/app/Http/Controllers/BancardV2Controller.php
+++ b/app/Http/Controllers/BancardV2Controller.php
@@ -354,9 +354,32 @@ class BancardV2Controller extends Controller
         if ($order->status !== 'paid') {
             $order->status = 'paid';
             $order->save();
+
+            $this->reduceOrderStock($order);
         }
 
         Cart::where('user_id', $order->user_id)->delete();
+    }
+
+    private function reduceOrderStock(Order $order): void
+    {
+        $order->loadMissing('items.product');
+
+        foreach ($order->items as $item) {
+            $product = $item->product;
+
+            if (!$product) {
+                continue;
+            }
+
+            $quantity = max(0, (int) $item->quantity);
+            $availableStock = max(0, (int) $product->stock);
+            $decrementBy = min($quantity, $availableStock);
+
+            if ($decrementBy > 0) {
+                $product->decrement('stock', $decrementBy);
+            }
+        }
     }
 
     private function resolvePygSymbol(): string

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -76,16 +76,17 @@ class CartController extends Controller
         $symbol = $currency->sign ?? 'R$';
         $decimal = $currency->decimal_separator ?? ',';
         $thousand = $currency->thousands_separator ?? '.';
+        $decimals = $currency->decimal_digits ?? 2;
         $rate = $currency->value ?? 1;
 
-        $cart->transform(function ($item) use ($symbol, $decimal, $thousand, $rate) {
+        $cart->transform(function ($item) use ($symbol, $decimal, $thousand, $decimals, $rate) {
             if ($item->product) {
                 $price = ($item->product->price ?? 0) * $rate;
-                $item->product->formatted_price = $symbol . ' ' . number_format($price, 2, $decimal, $thousand);
+                $item->product->formatted_price = $symbol . ' ' . number_format($price, $decimals, $decimal, $thousand);
 
                 if ($item->product->previous_price) {
                     $prev = $item->product->previous_price * $rate;
-                    $item->product->formatted_previous_price = $symbol . ' ' . number_format($prev, 2, $decimal, $thousand);
+                    $item->product->formatted_previous_price = $symbol . ' ' . number_format($prev, $decimals, $decimal, $thousand);
                 }
             }
             return $item;

--- a/resources/views/admin/coin/index.blade.php
+++ b/resources/views/admin/coin/index.blade.php
@@ -32,7 +32,7 @@
 
                     <div class="bg-light p-3 mb-3 border-start border-3 {{ $currency->is_default ? 'border-dark' : 'border-secondary' }}">
                         <span class="sax-label">Valor de Conversión</span>
-                        <span class="h4 fw-light font-monospace m-0">{{ number_format($currency->value, 4) }}</span>
+                        <span class="h4 fw-light font-monospace m-0">{{ number_format($currency->value, $currency->decimal_digits ?? 2, $currency->decimal_separator ?? '.', $currency->thousands_separator ?? ',') }}</span>
                     </div>
 
                     <div class="d-flex gap-3 pt-2 border-top">
@@ -55,8 +55,13 @@
             <div class="modal-dialog modal-dialog-centered modal-lg">
                 <form action="{{ route('admin.currencies.update', $currency->id) }}" method="POST" class="modal-content rounded-0 border-0 shadow-lg">
                     @csrf @method('PUT')
-                    <div class="modal-header border-bottom py-3 px-4">
-                        <h6 class="modal-title text-uppercase fw-bold tracking-wider x-small">Configuração de Moeda: {{ $currency->name }}</h6>
+                    <div class="modal-header border-bottom py-3 px-4 d-flex align-items-center justify-content-between">
+                        <div class="d-flex align-items-center gap-2">
+                            <h6 class="modal-title text-uppercase fw-bold tracking-wider x-small mb-0">Configuração de Moeda: {{ $currency->name }}</h6>
+                            @if($currency->is_default)
+                                <span class="badge bg-dark rounded-0 x-small tracking-tighter">BASE / DEFAULT</span>
+                            @endif
+                        </div>
                         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                     </div>
                     <div class="modal-body p-4">

--- a/resources/views/components/carrinho-header.blade.php
+++ b/resources/views/components/carrinho-header.blade.php
@@ -26,6 +26,7 @@
     $symbol = $currency->sign ?? 'R$';
     $decimal = $currency->decimal_separator ?? ',';
     $thousand = $currency->thousands_separator ?? '.';
+    $decimals = $currency->decimal_digits ?? 2;
     $rate = $currency->value ?? 1;
 @endphp
 
@@ -68,7 +69,7 @@
                             $subtotalItem = $convertedPrice * $item->quantity;
                             $totalGeral += $subtotalItem;
 
-                            $formattedPrice = $symbol . ' ' . number_format($convertedPrice, 2, $decimal, $thousand);
+                            $formattedPrice = $symbol . ' ' . number_format($convertedPrice, $decimals, $decimal, $thousand);
                         @endphp
                         <div class="cart-item">
                             <div class="item-image">
@@ -120,7 +121,7 @@
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <span class="fw-bold">SUBTOTAL:</span>
                     <span class="fw-bold h5 mb-0 text-dark">
-                        {{ $symbol . ' ' . number_format($totalGeral, 2, $decimal, $thousand) }}
+                        {{ $symbol . ' ' . number_format($totalGeral, $decimals, $decimal, $thousand) }}
                     </span>
                 </div>
                 <a href="{{ route('cart.view') }}" class="btn-go-to-cart w-100 py-3">IR PARA O CARRINHO</a>

--- a/resources/views/payment/bancard-v2-error.blade.php
+++ b/resources/views/payment/bancard-v2-error.blade.php
@@ -27,8 +27,8 @@
                                     <td>{{ $shopProcessId }}</td>
                                 </tr>
                                 <tr>
-                                    <th scope="row" class="text-muted">Importe</th>
-                                    <td>{{ $amount }} PYG</td>
+                                    <th scope="row" class="text-muted">Valor pago</th>
+                                    <td>{{ $pygSymbol ?? 'G$' }} {{ number_format((float) $amount, 0, ',', '.') }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row" class="text-muted">Descricao da resposta</th>

--- a/resources/views/payment/bancard-v2-success.blade.php
+++ b/resources/views/payment/bancard-v2-success.blade.php
@@ -27,8 +27,8 @@
                                     <td>{{ $shopProcessId }}</td>
                                 </tr>
                                 <tr>
-                                    <th scope="row" class="text-muted">Importe</th>
-                                    <td>{{ $amount }} PYG</td>
+                                    <th scope="row" class="text-muted">Valor pago</th>
+                                    <td>{{ $pygSymbol ?? 'G$' }} {{ number_format((float) $amount, 0, ',', '.') }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row" class="text-muted">Descricao da resposta</th>

--- a/resources/views/payment/bancard-v2.blade.php
+++ b/resources/views/payment/bancard-v2.blade.php
@@ -17,7 +17,11 @@
                 </div>
                 <div class="bancard-meta-item">
                     <span class="meta-label">Total</span>
-                    <strong class="meta-value">{{ number_format((float) $order->total, 2, ',', '.') }}</strong>
+                    <strong class="meta-value">{{ currency_format((float) $order->total) }}</strong>
+                </div>
+                <div class="bancard-meta-item">
+                    <span class="meta-label">Total PYG</span>
+                    <strong class="meta-value">{{ $pygSymbol }} {{ number_format((float) $totalInPyg, 0, ',', '.') }}</strong>
                 </div>
                 <div class="bancard-meta-item">
                     <span class="meta-label">Status</span>
@@ -83,7 +87,7 @@
 
     .bancard-meta-grid {
         display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(4, minmax(0, 1fr));
         gap: 8px;
         margin: 16px 0 14px;
     }


### PR DESCRIPTION
# Descrição:

- Este PR consolida melhorias no fluxo Bancard V2 com foco em consistência de moeda, clareza de interface e integridade de estoque após confirmação de pagamento.

# Principais alterações:

- Padroniza a exibição de valores no checkout Bancard V2 conforme a moeda ativa do sistema.
- Exibe o total em PYG no checkout com formatação adequada para Guarani.
- Ajusta as telas de sucesso e erro do Bancard V2 para usar o mesmo padrão visual de moeda.
- Substitui o rótulo “Importe” por “Valor pago” para melhorar entendimento do usuário.
- Aplica baixa de estoque no momento em que o pedido Bancard V2 é confirmado como pago.
- Garante que a baixa de estoque ocorra apenas uma vez por pedido (evitando dupla execução em callback/retorno).
- Evita estoque negativo ao limitar o abatimento ao saldo disponível.

# Resultado esperado:

- Fluxo Bancard V2 mais coerente com o restante do checkout.
- Informações financeiras apresentadas de forma consistente para o usuário.
- Estoque refletindo corretamente pedidos aprovados via Bancard V2.
- Redução de risco de divergência entre status do pedido e inventário.

# Evidências

<img width="877" height="733" alt="Screenshot 2026-04-01 at 21 28 49" src="https://github.com/user-attachments/assets/9a051110-4f5c-480f-824c-277a74a9878b" />

<img width="916" height="598" alt="Screenshot 2026-04-01 at 21 29 35" src="https://github.com/user-attachments/assets/a6a7744e-7078-4cc7-9320-8fb7c1fc991f" />

<img width="1354" height="517" alt="image" src="https://github.com/user-attachments/assets/c4d0da99-a5ab-4e01-977c-0f9bab619bc3" />

<img width="814" height="442" alt="image" src="https://github.com/user-attachments/assets/5e9432a8-86af-40cb-b523-89c7b75bfada" />

<img width="238" height="190" alt="image" src="https://github.com/user-attachments/assets/24e85352-a2e1-4992-97ad-788c4f5e9386" />

